### PR TITLE
change -2 to -3 to align with the following graph and text AND remove duplicate word `determine`

### DIFF
--- a/src/05-containers/01-sequence-containers.md
+++ b/src/05-containers/01-sequence-containers.md
@@ -129,7 +129,7 @@ d.push_front(2); `[]`
 d.push_front(1);
 d.push_front(0);
 d.push_front(-1);
-d.push_front(-2); `[]`
+d.push_front(-3); `[]`
 ```
 
 ```memory

--- a/src/05-containers/02-associative-containers.md
+++ b/src/05-containers/02-associative-containers.md
@@ -208,7 +208,7 @@ L2 {
 }
 ```
 
-A `set` uses the same red-black tree data structure under the hood to determine quickly determine if an element exists inside a set. `set` has no concept of a key-value pair, so its `TreeNode` behind the scenes is somewhat simpler: rather than storing a `pair` of key and value, it directly stores the set element in the node. Otherwise, `set` and `map` work exactly the same: conceptually, you can think of a `set` being somewhat like a `map` without any values.
+A `set` uses the same red-black tree data structure under the hood to quickly determine if an element exists inside a set. `set` has no concept of a key-value pair, so its `TreeNode` behind the scenes is somewhat simpler: rather than storing a `pair` of key and value, it directly stores the set element in the node. Otherwise, `set` and `map` work exactly the same: conceptually, you can think of a `set` being somewhat like a `map` without any values.
 
 ## Unordered Containers
 


### PR DESCRIPTION
Fix [issue](https://github.com/cs106l/textbook/issues/10) I opened earlier：

> The issue reports a discrepancy in the “Sequence Containers/Behind the Scenes” section of the CS106L textbook: the code snippet shows pushing -2 to the front of deque d, but the accompanying graph and explanatory text refer to pushing -3. The value used in the code does not match the value shown in the graph and text, and they should be made consistent.

Summary generated by Copilot:

> This pull request makes a minor change to the sequence of values being pushed to the front of a container in the `src/05-containers/01-sequence-containers.md` file. The value `-2` is replaced with `-3` in the example.